### PR TITLE
Prevent UnleashConfig from using a static executor instance

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashCreator.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashCreator.java
@@ -5,6 +5,7 @@ import io.getunleash.Unleash;
 import io.getunleash.event.UnleashSubscriber;
 import io.getunleash.repository.ToggleBootstrapProvider;
 import io.getunleash.util.UnleashConfig;
+import io.getunleash.util.UnleashScheduledExecutorImpl;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;
@@ -14,7 +15,12 @@ public class UnleashCreator {
     public static Unleash createUnleash(UnleashRuntimeTimeConfig unleashRuntimeTimeConfig, String name) {
         UnleashConfig.Builder builder = UnleashConfig.builder()
                 .unleashAPI(unleashRuntimeTimeConfig.url)
-                .appName(name);
+                .appName(name)
+                /*
+                 * This is needed to prevent UnleashConfig from using a static executor instance
+                 * which doesn't work well in dev mode when Quarkus is live reloaded.
+                 */
+                .scheduledExecutor(new UnleashScheduledExecutorImpl());
 
         unleashRuntimeTimeConfig.instanceId.ifPresent(builder::instanceId);
         unleashRuntimeTimeConfig.token.ifPresent(s -> builder.customHttpHeader("Authorization", s));

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashLifecycleManager.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashLifecycleManager.java
@@ -1,8 +1,5 @@
 package io.quarkiverse.unleash.runtime;
 
-import static io.quarkus.runtime.LaunchMode.DEVELOPMENT;
-import static io.quarkus.runtime.configuration.ProfileManager.getLaunchMode;
-
 import jakarta.enterprise.event.Observes;
 import jakarta.enterprise.event.Shutdown;
 import jakarta.enterprise.event.Startup;
@@ -18,14 +15,6 @@ public class UnleashLifecycleManager {
     }
 
     void onShutdown(@Observes Shutdown event, Unleash unleash) {
-        if (getLaunchMode() == DEVELOPMENT) {
-            /*
-             * If the Unleash client is shut down when Quarkus is live reloaded, the underlying ScheduledThreadPoolExecutor
-             * will be shut down and no longer accept new tasks after Quarkus is done restarting. We need to keep the
-             * executor alive in dev mode so that it'll keep working after the live reload.
-             */
-            return;
-        }
         try {
             unleash.shutdown();
         } catch (Exception e) {


### PR DESCRIPTION
Fixes #228.

When no executor is passed to the Unleash client builder, `UnleashConfig` will use a `static` executor instance by default. This doesn't work well in dev mode because the executor instance keeps living after a live reload even if it was shut down. That's why we had a workaround which is removed by this PR.

Now, we're simply making sure a new executor instance is created every time an Unleash client instance is created.

See [this](https://github.com/Unleash/unleash-client-java/blob/b2ac9aee6aecbd3e968ed5c0e51bb5fca1c60452/src/main/java/io/getunleash/util/UnleashConfig.java#L705-L706) and [that](https://github.com/Unleash/unleash-client-java/blob/b2ac9aee6aecbd3e968ed5c0e51bb5fca1c60452/src/main/java/io/getunleash/util/UnleashScheduledExecutorImpl.java#L32-L37) for more details about the static executor.