### PR TITLE
Make UnleashSubscriber unremovable

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/unleash/UnleashProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/unleash/UnleashProcessor.java
@@ -27,6 +27,7 @@ import org.jboss.jandex.Type;
 
 import io.getunleash.Unleash;
 import io.getunleash.Variant;
+import io.getunleash.event.UnleashSubscriber;
 import io.quarkiverse.unleash.runtime.AbstractVariantProducer;
 import io.quarkiverse.unleash.runtime.FeatureToggleProducer;
 import io.quarkiverse.unleash.runtime.ToggleVariantProducer;
@@ -123,7 +124,8 @@ public class UnleashProcessor {
         return AdditionalBeanBuildItem.builder()
                 .setUnremovable()
                 .addBeanClasses(UnleashLifecycleManager.class, FeatureToggle.class, FeatureToggleProducer.class,
-                        UnleashResourceProducer.class, ToggleVariantProducer.class, ToggleVariantStringProducer.class)
+                        UnleashResourceProducer.class, ToggleVariantProducer.class, ToggleVariantStringProducer.class,
+                        UnleashSubscriber.class)
                 .build();
     }
 

--- a/deployment/src/test/java/io/quarkiverse/unleash/ClientRegisteredUnleashSubscriber.java
+++ b/deployment/src/test/java/io/quarkiverse/unleash/ClientRegisteredUnleashSubscriber.java
@@ -4,10 +4,8 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 import io.getunleash.event.UnleashSubscriber;
 import io.getunleash.metric.ClientRegistration;
-import io.quarkus.arc.Unremovable;
 
 @ApplicationScoped
-@Unremovable
 public class ClientRegisteredUnleashSubscriber implements UnleashSubscriber {
 
     private boolean clientRegistered;

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -115,7 +115,6 @@ import io.quarkus.arc.Unremovable;
 import io.quarkus.logging.Log;
 
 @ApplicationScoped // <1>
-@Unremovable // <2>
 public class ToggleChangedLogger implements UnleashSubscriber {
 
     private static final Set<String> TOGGLE_NAMES = Set.of("my-toggle-1", "my-toggle-2");
@@ -142,7 +141,6 @@ public class ToggleChangedLogger implements UnleashSubscriber {
 }
 ----
 <1> The `UnleashSubscriber` implementation has to be a CDI bean.
-<2> The bean will be considered unused and will be automatically removed if it is not annotated with `@Unremovable`.
 
 === Bootstrapping toggles from a JSON string
 


### PR DESCRIPTION
This improves the Quarkus users experience as they no longer need to annotate their `UnleashSubscriber` implementation with `@Unremovable`.