### PR TITLE
Add UnleashContext support

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/unleash/UnleashProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/unleash/UnleashProcessor.java
@@ -28,13 +28,7 @@ import org.jboss.jandex.Type;
 import io.getunleash.Unleash;
 import io.getunleash.Variant;
 import io.getunleash.event.UnleashSubscriber;
-import io.quarkiverse.unleash.runtime.AbstractVariantProducer;
-import io.quarkiverse.unleash.runtime.FeatureToggleProducer;
-import io.quarkiverse.unleash.runtime.ToggleVariantProducer;
-import io.quarkiverse.unleash.runtime.ToggleVariantStringProducer;
-import io.quarkiverse.unleash.runtime.UnleashLifecycleManager;
-import io.quarkiverse.unleash.runtime.UnleashRecorder;
-import io.quarkiverse.unleash.runtime.UnleashResourceProducer;
+import io.quarkiverse.unleash.runtime.*;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanBuildItem;
 import io.quarkus.arc.deployment.GeneratedBeanGizmoAdaptor;
@@ -125,7 +119,7 @@ public class UnleashProcessor {
                 .setUnremovable()
                 .addBeanClasses(UnleashLifecycleManager.class, FeatureToggle.class, FeatureToggleProducer.class,
                         UnleashResourceProducer.class, ToggleVariantProducer.class, ToggleVariantStringProducer.class,
-                        UnleashSubscriber.class)
+                        UnleashSubscriber.class, UnleashContextProvider.class, UnleashContextProducer.class)
                 .build();
     }
 

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,5 +1,5 @@
-:project-version: 1.5.0
-:quarkus-version: 3.8.2
+:project-version: 1.6.0
+:quarkus-version: 3.9.1
 
 :quarkus-org-url: https://github.com/quarkusio
 :quarkus-base-url: {quarkus-org-url}/quarkus

--- a/integration-tests/src/main/java/io/quarkiverse/unleash/it/AppContextCustomizer.java
+++ b/integration-tests/src/main/java/io/quarkiverse/unleash/it/AppContextCustomizer.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.unleash.it;
+
+import jakarta.enterprise.context.*;
+import jakarta.ws.rs.core.*;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import io.getunleash.UnleashContext;
+import io.quarkiverse.unleash.runtime.UnleashContextCustomizer;
+import io.quarkus.logging.Log;
+
+@ApplicationScoped
+public class AppContextCustomizer implements UnleashContextCustomizer {
+
+    @ConfigProperty(name = "environment", defaultValue = "default")
+    String environment;
+
+    @Override
+    public void apply(UnleashContext.Builder builder) {
+        Log.info("Applying AppContextCustomizer");
+        builder.environment(environment);
+    }
+
+    @Override
+    public boolean isApplicationContext() {
+        return true;
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/unleash/it/ContextRestController.java
+++ b/integration-tests/src/main/java/io/quarkiverse/unleash/it/ContextRestController.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.unleash.it;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+
+import jakarta.enterprise.context.*;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.*;
+
+import io.getunleash.*;
+import io.quarkiverse.unleash.FeatureToggle;
+import io.quarkiverse.unleash.runtime.UnleashContextProvider;
+
+@Path("context")
+@Produces(MediaType.APPLICATION_JSON)
+public class ContextRestController {
+
+    @Inject
+    Unleash unleash;
+
+    @FeatureToggle(name = "rollout")
+    Instance<Boolean> feature;
+
+    @Inject
+    UnleashContextProvider contextProvider;
+
+    @Inject
+    UnleashContext context;
+
+    @GET
+    public Response testMethod() {
+        CompletableFuture<Map<String, Object>> appFuture = new CompletableFuture<>();
+        new Thread(() -> appFuture.complete(getApplicationFlags())).start();
+
+        Map<String, Object> tmp = appFuture.join();
+        tmp.put("request", feature.get());
+        tmp.put("request-environment", context.getEnvironment().orElse(null));
+        tmp.put("request-userId", context.getUserId().orElse(null));
+        return Response.ok(tmp).build();
+    }
+
+    private Map<String, Object> getApplicationFlags() {
+        UnleashContext appContext = contextProvider.get();
+        Map<String, Object> tmp = new HashMap<>();
+        tmp.put("application", feature.get());
+        tmp.put("application-environment", appContext.getEnvironment().orElse(null));
+        tmp.put("application-userId", appContext.getUserId().orElse(null));
+        return tmp;
+    }
+
+    @GET
+    @Path("{name}")
+    public Boolean get(@PathParam("name") String name) {
+        return unleash.isEnabled(name, false);
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/unleash/it/RequestContextCustomizer.java
+++ b/integration-tests/src/main/java/io/quarkiverse/unleash/it/RequestContextCustomizer.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.unleash.it;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.ws.rs.core.UriInfo;
+
+import org.jboss.resteasy.spi.ResteasyProviderFactory;
+
+import io.getunleash.UnleashContext;
+import io.quarkiverse.unleash.runtime.UnleashContextCustomizer;
+import io.quarkus.logging.Log;
+
+@RequestScoped
+public class RequestContextCustomizer implements UnleashContextCustomizer {
+
+    @Override
+    public void apply(UnleashContext.Builder builder) {
+        Log.info("Applying RequestContextCustomizer");
+        UriInfo info = ResteasyProviderFactory.getInstance().getContextData(UriInfo.class);
+        builder.userId(info.getQueryParameters().getFirst("userId"))
+                .addProperty("betaEnabled", info.getQueryParameters().getFirst("betaEnabled"));
+    }
+}

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -11,5 +11,7 @@ quarkus.container-image.group=quarkiverse
 quarkus.unleash.devservices.enabled=true
 quarkus.unleash.devservices.import-file=src/test/resources/unleash-export.yml
 
+quarkus.log.category."io.quarkiverse.unleash".level=debug
+
 %test.quarkus.unleash.fetch-toggles-interval=2
 %prod.quarkus.unleash.fetch-toggles-interval=2

--- a/integration-tests/src/test/java/io/quarkiverse/unleash/it/UnleashTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/unleash/it/UnleashTest.java
@@ -169,7 +169,7 @@ public class UnleashTest {
         Assertions.assertEquals("default", flags.get("request-environment"));
         Assertions.assertEquals("default", flags.get("application-environment"));
         Assertions.assertEquals(userId, flags.get("request-userId"));
-        Assertions.assertEquals(null, flags.get("application-userId"));
+        Assertions.assertNull(flags.get("application-userId"));
         Assertions.assertEquals(false, flags.get("application"));
         Assertions.assertEquals(expected, flags.get("request"));
     }

--- a/integration-tests/src/test/resources/unleash-export.yml
+++ b/integration-tests/src/test/resources/unleash-export.yml
@@ -21,6 +21,13 @@ features:
     stale: false
     createdAt: 2021-11-08T21:01:37.477Z
     lastSeenAt: null
+  - name: rollout
+    description: ''
+    type: release
+    project: default
+    stale: false
+    createdAt: 2021-11-08T21:01:37.477Z
+    lastSeenAt: null
 strategies: [ ]
 projects: [ ]
 tagTypes: [ ]
@@ -50,6 +57,21 @@ featureStrategies:
     strategyName: default
     parameters: { }
     constraints: [ ]
+    createdAt: 2021-11-08T21:01:37.486Z
+  - id: 1b65b714-e7fa-43b5-8cdb-6abdf1307b1e
+    featureName: rollout
+    projectId: default
+    environment: default
+    strategyName: flexibleRollout
+    parameters:
+      groupId: rollout
+      stickiness: default
+      rollout: 50
+    constraints:
+      - contextName: betaEnabled
+        operator: IN
+        values:
+        - "true"
     createdAt: 2021-11-08T21:01:37.486Z
 environments:
   - name: default
@@ -88,3 +110,7 @@ featureEnvironments:
         overrides: []
         stickiness: default
         weightType: variable
+  - enabled: true
+    featureName: rollout
+    environment: default
+    variants: []

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/FeatureToggleProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/FeatureToggleProducer.java
@@ -2,21 +2,33 @@ package io.quarkiverse.unleash.runtime;
 
 import java.lang.annotation.Annotation;
 
-import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.*;
 import jakarta.enterprise.inject.spi.InjectionPoint;
 import jakarta.inject.Inject;
 
+import org.jboss.logging.Logger;
+
 import io.getunleash.Unleash;
+import io.getunleash.UnleashContext;
 import io.quarkiverse.unleash.FeatureToggle;
 
 public class FeatureToggleProducer {
 
+    private static final Logger LOGGER = Logger.getLogger(FeatureToggleProducer.class);
+
     @Inject
     Unleash unleash;
 
+    @Inject
+    UnleashContextProvider contextProvider;
+
     @Produces
     @FeatureToggle(name = "ignored")
-    boolean getFeatureToggle(InjectionPoint injectionPoint) {
+    boolean getRequestFeatureToggle(InjectionPoint injectionPoint) {
+        return getFeatureToggle(injectionPoint, contextProvider.get());
+    }
+
+    private boolean getFeatureToggle(InjectionPoint injectionPoint, UnleashContext context) {
         FeatureToggle ft = null;
         for (Annotation qualifier : injectionPoint.getQualifiers()) {
             if (qualifier.annotationType().equals(FeatureToggle.class)) {
@@ -24,7 +36,29 @@ public class FeatureToggleProducer {
                 break;
             }
         }
-        return unleash.isEnabled(ft.name(), ft.defaultValue());
+        boolean value = unleash.isEnabled(ft.name(), context, ft.defaultValue());
+        logToggleResult(ft, value, context);
+        return value;
     }
 
+    private void logToggleResult(FeatureToggle ft, boolean value, UnleashContext context) {
+        if (!LOGGER.isDebugEnabled())
+            return;
+        StringBuilder sb = new StringBuilder("Feature ")
+                .append(ft.name())
+                .append(" is ")
+                .append(value)
+                .append(" (");
+        int length = sb.length();
+        context.getAppName().ifPresent(v -> sb.append("appName=").append(v).append(", "));
+        context.getEnvironment().ifPresent(v -> sb.append("environment=").append(v).append(", "));
+        context.getUserId().ifPresent(v -> sb.append("userId=").append(v).append(", "));
+        context.getSessionId().ifPresent(v -> sb.append("sessionId=").append(v).append(", "));
+        context.getRemoteAddress().ifPresent(v -> sb.append("remoteAddress=").append(v).append(", "));
+        context.getProperties().forEach((k, v) -> sb.append(k).append("=").append(v).append(", "));
+        sb.setLength(sb.length() - 2);
+        if (length < sb.length())
+            sb.append(") ");
+        LOGGER.debug(sb);
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashContextCustomizer.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashContextCustomizer.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.unleash.runtime;
+
+import io.getunleash.UnleashContext;
+
+public interface UnleashContextCustomizer {
+
+    void apply(UnleashContext.Builder builder);
+
+    default boolean isApplicationContext() {
+        return false;
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashContextProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashContextProducer.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.unleash.runtime;
+
+import java.util.List;
+
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.inject.*;
+import jakarta.inject.Inject;
+
+import io.getunleash.UnleashContext;
+
+public class UnleashContextProducer {
+
+    @Inject
+    UnleashContextProvider provider;
+
+    private List<UnleashContextCustomizer> requestCustomizers;
+
+    @Inject
+    void setRequestCustomizers(Instance<UnleashContextCustomizer> customizers) {
+        requestCustomizers = customizers.stream()
+                .filter(c -> !c.isApplicationContext())
+                .toList();
+    }
+
+    @Produces
+    @RequestScoped
+    public UnleashContext getRequestContext() {
+        if (requestCustomizers.isEmpty()) {
+            return provider.getApplicationContext();
+        }
+        UnleashContext.Builder builder = new UnleashContext.Builder(provider.getApplicationContext());
+        requestCustomizers.forEach(c -> c.apply(builder));
+        return builder.build();
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashContextProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashContextProvider.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.unleash.runtime;
+
+import java.util.*;
+
+import jakarta.enterprise.context.*;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.*;
+
+import io.getunleash.UnleashContext;
+import io.quarkus.arc.Arc;
+
+@ApplicationScoped
+public class UnleashContextProvider {
+
+    private UnleashContext applicationContext;
+
+    @Inject
+    UnleashContext requestContext;
+
+    @Inject
+    void setCustomizers(Instance<UnleashContextCustomizer> customizers) {
+        UnleashContext.Builder builder = UnleashContext.builder();
+        customizers.handlesStream()
+                .filter(h -> STATIC_SCOPES.contains(h.getBean().getScope()))
+                .map(Instance.Handle::get)
+                .filter(UnleashContextCustomizer::isApplicationContext)
+                .forEach(c -> c.apply(builder));
+        applicationContext = builder.build();
+    }
+
+    public UnleashContext getApplicationContext() {
+        return applicationContext;
+    }
+
+    public UnleashContext getRequestContext() {
+        return requestContext;
+    }
+
+    public UnleashContext get() {
+        if (Arc.container().requestContext().isActive()) {
+            return getRequestContext();
+        } else {
+            return getApplicationContext();
+        }
+    }
+
+    static final Set<Class<?>> STATIC_SCOPES = Set.of(ApplicationScoped.class, Singleton.class, Dependent.class);
+}

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashRecorder.java
@@ -29,7 +29,7 @@ public class UnleashRecorder {
                 @Override
                 public Unleash get() {
                     Unleash unleash = UnleashCreator.createUnleash(unleashRuntimeConfig.getValue(), app);
-                    LOGGER.infof("Unleash client application '{}' fetch feature toggle names: {}", app,
+                    LOGGER.infof("Unleash client application '%s' fetch feature toggle names: %s", app,
                             unleash.more().getFeatureToggleNames());
                     return unleash;
                 }


### PR DESCRIPTION
UnleashContext allows gradual rollout of features based on userId, amongst other things.

This MR adds a @RequestScoped UnleashContext that is used by the feature toggle producer.

Applications can use customizers to modify the context.

**Design decisions:**

Customizer vs Producer

* a context can hold data from many different sources
* by using customizers, multiple sources (eg extensions) can modify the context
* if multiple customizers modify the same property, the outcome may be undeterministic, though

ApplicationScoped vs RequestScoped vs Dependent 

* the main use case for contexts is changing a feature based on request specifics
* thus, UnleashContext is @RequestScoped, to avoid accidentally using it outside of a request context
* additionally, a UnleashContextProvider can be used to get an UnleashContext in the application scope
* FeatureToggleProducer will automatically use the context from the correct scope
  * this has the risk of accidentally calling a request-based feature toggle from outside a request scope (eg, a rollout with default stickiness would toggle randomly in application scope)
  * but changing that would break existing code
* Dependent would mean that all customizers have to be invoked every time a feature toggle is evaluated, the other scopes allow re-using the context

UnleashContextCustomizer#isApplicationContext

* every customizer can declare if they want to apply in ApplicationScoped or in RequestScoped
* we can't use the scope of the bean to determine this, as a ApplicationScoped bean can use RequestScoped injections
* ApplicationScoped customizers are only applied once

**Future work:**

* add a property to the feature toggle annotation to explicitly choose the scope (eg, checking a RequestScoped toggle outside a request context should fail)
* add configuration options to configure the UnleashContext feature
* add default customizers for common extensions