### PR TITLE
Fix #308 Docs Icon URL

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -8,5 +8,6 @@ metadata:
   categories:
     - "feature management"
   status: "preview"
+  icon-url: "https://docs.getunleash.io/img/logo.svg"
   config:
     - "quarkus.unleash."


### PR DESCRIPTION
Fix #308 Docs Icon URL



![image](https://github.com/user-attachments/assets/f3c64979-f414-4707-bd44-885b9510d6ab)