### PR TITLE
Add support for custom headers

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-unleash.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-unleash.adoc
@@ -544,27 +544,6 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-unleash_quarkus-unleash-custom-header-custom-headers]] [.property-path]##link:#quarkus-unleash_quarkus-unleash-custom-header-custom-headers[`quarkus.unleash.custom-header."custom-headers"`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.unleash.custom-header."custom-headers"+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Custom HTTP headers to be sent with requests to Unleash server. Example: quarkus.unleash.custom-header.X-Custom-Header=value
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_UNLEASH_CUSTOM_HEADER__CUSTOM_HEADERS_+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_UNLEASH_CUSTOM_HEADER__CUSTOM_HEADERS_+++`
-endif::add-copy-button-to-env-var[]
---
-|Map<String,String>
-|
-
 a| [[quarkus-unleash_quarkus-unleash-custom-headers-name]] [.property-path]##link:#quarkus-unleash_quarkus-unleash-custom-headers-name[`quarkus.unleash.custom-headers.name`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.unleash.custom-headers.name+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-unleash.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-unleash.adoc
@@ -565,5 +565,47 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
+a| [[quarkus-unleash_quarkus-unleash-custom-headers-name]] [.property-path]##link:#quarkus-unleash_quarkus-unleash-custom-headers-name[`quarkus.unleash.custom-headers.name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.unleash.custom-headers.name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the custom HTTP header. Example: X-Api-Key or $++{++HEADER_NAME++}++ to use an environment variable
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_UNLEASH_CUSTOM_HEADERS_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_UNLEASH_CUSTOM_HEADERS_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-unleash_quarkus-unleash-custom-headers-value]] [.property-path]##link:#quarkus-unleash_quarkus-unleash-custom-headers-value[`quarkus.unleash.custom-headers.value`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.unleash.custom-headers.value+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The value of the custom HTTP header. Example: secret-value or $++{++HEADER_VALUE++}++ to use an environment variable
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_UNLEASH_CUSTOM_HEADERS_VALUE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_UNLEASH_CUSTOM_HEADERS_VALUE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-unleash.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-unleash.adoc
@@ -544,5 +544,26 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-unleash_quarkus-unleash-custom-header-custom-headers]] [.property-path]##link:#quarkus-unleash_quarkus-unleash-custom-header-custom-headers[`quarkus.unleash.custom-header."custom-headers"`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.unleash.custom-header."custom-headers"+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Custom HTTP headers to be sent with requests to Unleash server. Example: quarkus.unleash.custom-header.X-Custom-Header=value
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_UNLEASH_CUSTOM_HEADER__CUSTOM_HEADERS_+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_UNLEASH_CUSTOM_HEADER__CUSTOM_HEADERS_+++`
+endif::add-copy-button-to-env-var[]
+--
+|Map<String,String>
+|
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-unleash_quarkus.unleash.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-unleash_quarkus.unleash.adoc
@@ -544,27 +544,6 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
-a| [[quarkus-unleash_quarkus-unleash-custom-header-custom-headers]] [.property-path]##link:#quarkus-unleash_quarkus-unleash-custom-header-custom-headers[`quarkus.unleash.custom-header."custom-headers"`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.unleash.custom-header."custom-headers"+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-Custom HTTP headers to be sent with requests to Unleash server. Example: quarkus.unleash.custom-header.X-Custom-Header=value
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_UNLEASH_CUSTOM_HEADER__CUSTOM_HEADERS_+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_UNLEASH_CUSTOM_HEADER__CUSTOM_HEADERS_+++`
-endif::add-copy-button-to-env-var[]
---
-|Map<String,String>
-|
-
 a| [[quarkus-unleash_quarkus-unleash-custom-headers-name]] [.property-path]##link:#quarkus-unleash_quarkus-unleash-custom-headers-name[`quarkus.unleash.custom-headers.name`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.unleash.custom-headers.name+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-unleash_quarkus.unleash.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-unleash_quarkus.unleash.adoc
@@ -565,5 +565,47 @@ endif::add-copy-button-to-env-var[]
 |Map<String,String>
 |
 
+a| [[quarkus-unleash_quarkus-unleash-custom-headers-name]] [.property-path]##link:#quarkus-unleash_quarkus-unleash-custom-headers-name[`quarkus.unleash.custom-headers.name`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.unleash.custom-headers.name+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The name of the custom HTTP header. Example: X-Api-Key or $++{++HEADER_NAME++}++ to use an environment variable
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_UNLEASH_CUSTOM_HEADERS_NAME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_UNLEASH_CUSTOM_HEADERS_NAME+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
+a| [[quarkus-unleash_quarkus-unleash-custom-headers-value]] [.property-path]##link:#quarkus-unleash_quarkus-unleash-custom-headers-value[`quarkus.unleash.custom-headers.value`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.unleash.custom-headers.value+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The value of the custom HTTP header. Example: secret-value or $++{++HEADER_VALUE++}++ to use an environment variable
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_UNLEASH_CUSTOM_HEADERS_VALUE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_UNLEASH_CUSTOM_HEADERS_VALUE+++`
+endif::add-copy-button-to-env-var[]
+--
+|string
+|required icon:exclamation-circle[title=Configuration property is required]
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-unleash_quarkus.unleash.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-unleash_quarkus.unleash.adoc
@@ -544,5 +544,26 @@ endif::add-copy-button-to-env-var[]
 |string
 |
 
+a| [[quarkus-unleash_quarkus-unleash-custom-header-custom-headers]] [.property-path]##link:#quarkus-unleash_quarkus-unleash-custom-header-custom-headers[`quarkus.unleash.custom-header."custom-headers"`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.unleash.custom-header."custom-headers"+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Custom HTTP headers to be sent with requests to Unleash server. Example: quarkus.unleash.custom-header.X-Custom-Header=value
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_UNLEASH_CUSTOM_HEADER__CUSTOM_HEADERS_+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_UNLEASH_CUSTOM_HEADER__CUSTOM_HEADERS_+++`
+endif::add-copy-button-to-env-var[]
+--
+|Map<String,String>
+|
+
 |===
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -31,6 +31,26 @@ Assuming you have `Unleash` running on localhost:4242 you should add the followi
 quarkus.unleash.url=http://localhost:4242/api
 ----
 
+==== Custom HTTP Headers
+
+You can add custom HTTP headers to requests sent to the Unleash server.
+
+Map-based approach (when header names are static):
+[source,properties]
+----
+quarkus.unleash.custom-header.X-Custom-Header=value
+quarkus.unleash.custom-header.X-Api-Key=${SECRET}
+----
+
+Indexed approach (when both header name and value are dynamic):
+[source,properties]
+----
+quarkus.unleash.custom-headers[0].name=${HEADER_NAME}
+quarkus.unleash.custom-headers[0].value=${HEADER_VALUE}
+quarkus.unleash.custom-headers[1].name=X-Correlation-Id
+quarkus.unleash.custom-headers[1].value=${CORRELATION_ID}
+----
+
 Once you have configured the properties, you can start using an Unleash-client.
 
 [source,java]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -34,21 +34,16 @@ quarkus.unleash.url=http://localhost:4242/api
 ==== Custom HTTP Headers
 
 You can add custom HTTP headers to requests sent to the Unleash server.
+Both the header name and value can be static or resolved from environment variables.
 
-Map-based approach (when header names are static):
 [source,properties]
 ----
-quarkus.unleash.custom-header.X-Custom-Header=value
-quarkus.unleash.custom-header.X-Api-Key=${SECRET}
-----
-
-Indexed approach (when both header name and value are dynamic):
-[source,properties]
-----
-quarkus.unleash.custom-headers[0].name=${HEADER_NAME}
-quarkus.unleash.custom-headers[0].value=${HEADER_VALUE}
-quarkus.unleash.custom-headers[1].name=X-Correlation-Id
-quarkus.unleash.custom-headers[1].value=${CORRELATION_ID}
+quarkus.unleash.custom-headers[0].name=X-Custom-Header
+quarkus.unleash.custom-headers[0].value=static-value
+quarkus.unleash.custom-headers[1].name=X-Api-Key
+quarkus.unleash.custom-headers[1].value=${SECRET}
+quarkus.unleash.custom-headers[2].name=${HEADER_NAME}
+quarkus.unleash.custom-headers[2].value=${HEADER_VALUE}
 ----
 
 Once you have configured the properties, you can start using an Unleash-client.

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashCreator.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashCreator.java
@@ -33,6 +33,9 @@ public class UnleashCreator {
         unleashRuntimeTimeConfig.backupFile().ifPresent(builder::backupFile);
         unleashRuntimeTimeConfig.namePrefix().ifPresent(builder::namePrefix);
         unleashRuntimeTimeConfig.customHeaders().forEach(builder::customHttpHeader);
+        unleashRuntimeTimeConfig.customHeadersList().forEach(header -> {
+            builder.customHttpHeader(header.name(), header.value());
+        });
 
         builder.fetchTogglesInterval(unleashRuntimeTimeConfig.fetchTogglesInterval());
         builder.sendMetricsInterval(unleashRuntimeTimeConfig.sendMetricsInterval());

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashCreator.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashCreator.java
@@ -32,6 +32,7 @@ public class UnleashCreator {
         unleashRuntimeTimeConfig.projectName().ifPresent(builder::projectName);
         unleashRuntimeTimeConfig.backupFile().ifPresent(builder::backupFile);
         unleashRuntimeTimeConfig.namePrefix().ifPresent(builder::namePrefix);
+        unleashRuntimeTimeConfig.customHeaders().forEach(builder::customHttpHeader);
 
         builder.fetchTogglesInterval(unleashRuntimeTimeConfig.fetchTogglesInterval());
         builder.sendMetricsInterval(unleashRuntimeTimeConfig.sendMetricsInterval());

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashCreator.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashCreator.java
@@ -32,10 +32,7 @@ public class UnleashCreator {
         unleashRuntimeTimeConfig.projectName().ifPresent(builder::projectName);
         unleashRuntimeTimeConfig.backupFile().ifPresent(builder::backupFile);
         unleashRuntimeTimeConfig.namePrefix().ifPresent(builder::namePrefix);
-        unleashRuntimeTimeConfig.customHeaders().forEach(builder::customHttpHeader);
-        unleashRuntimeTimeConfig.customHeadersList().forEach(header -> {
-            builder.customHttpHeader(header.name(), header.value());
-        });
+        unleashRuntimeTimeConfig.customHeaders().forEach(header -> builder.customHttpHeader(header.name(), header.value()));
 
         builder.fetchTogglesInterval(unleashRuntimeTimeConfig.fetchTogglesInterval());
         builder.sendMetricsInterval(unleashRuntimeTimeConfig.sendMetricsInterval());

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashRuntimeTimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashRuntimeTimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.unleash.runtime;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -118,4 +119,28 @@ public interface UnleashRuntimeTimeConfig {
      */
     @WithName("custom-header")
     Map<String, String> customHeaders();
+
+    /**
+     * Custom HTTP headers as indexed properties. This allows for fully dynamic headers where both name and value can come
+     * from environment variables.
+     */
+    @WithName("custom-headers")
+    List<CustomHeader> customHeadersList();
+
+    /**
+     * Custom header configuration for indexed properties
+     */
+    interface CustomHeader {
+        /**
+         * The name of the custom HTTP header.
+         * Example: X-Api-Key or ${HEADER_NAME} to use an environment variable
+         */
+        String name();
+
+        /**
+         * The value of the custom HTTP header.
+         * Example: secret-value or ${HEADER_VALUE} to use an environment variable
+         */
+        String value();
+    }
 }

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashRuntimeTimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashRuntimeTimeConfig.java
@@ -1,7 +1,6 @@
 package io.quarkiverse.unleash.runtime;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -115,20 +114,15 @@ public interface UnleashRuntimeTimeConfig {
 
     /**
      * Custom HTTP headers to be sent with requests to Unleash server.
-     * Example: quarkus.unleash.custom-header.X-Custom-Header=value
-     */
-    @WithName("custom-header")
-    Map<String, String> customHeaders();
-
-    /**
-     * Custom HTTP headers as indexed properties. This allows for fully dynamic headers where both name and value can come
-     * from environment variables.
+     * Both header name and value can be static or come from environment variables.
+     * Example: quarkus.unleash.custom-headers[0].name=X-Api-Key
+     * quarkus.unleash.custom-headers[0].value=${SECRET}
      */
     @WithName("custom-headers")
-    List<CustomHeader> customHeadersList();
+    List<CustomHeader> customHeaders();
 
     /**
-     * Custom header configuration for indexed properties
+     * Custom header configuration
      */
     interface CustomHeader {
         /**

--- a/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashRuntimeTimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/unleash/runtime/UnleashRuntimeTimeConfig.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.unleash.runtime;
 
+import java.util.Map;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigPhase;
@@ -110,4 +111,11 @@ public interface UnleashRuntimeTimeConfig {
      * If provided, the Unleash client will only fetch toggles whose name starts with the provided value.
      */
     Optional<String> namePrefix();
+
+    /**
+     * Custom HTTP headers to be sent with requests to Unleash server.
+     * Example: quarkus.unleash.custom-header.X-Custom-Header=value
+     */
+    @WithName("custom-header")
+    Map<String, String> customHeaders();
 }

--- a/test/src/main/java/io/quarkiverse/unleash/UnleashTestResource.java
+++ b/test/src/main/java/io/quarkiverse/unleash/UnleashTestResource.java
@@ -132,6 +132,11 @@ public class UnleashTestResource implements QuarkusTestResourceLifecycleManager,
                 public Optional<String> namePrefix() {
                     return Optional.empty();
                 }
+
+                @Override
+                public Map<String, String> customHeaders() {
+                    return Map.of();
+                }
             };
 
             CLIENT = UnleashCreator.createUnleash(configImpl, "quarkus-unleash-test");

--- a/test/src/main/java/io/quarkiverse/unleash/UnleashTestResource.java
+++ b/test/src/main/java/io/quarkiverse/unleash/UnleashTestResource.java
@@ -135,12 +135,7 @@ public class UnleashTestResource implements QuarkusTestResourceLifecycleManager,
                 }
 
                 @Override
-                public Map<String, String> customHeaders() {
-                    return Map.of();
-                }
-
-                @Override
-                public List<UnleashRuntimeTimeConfig.CustomHeader> customHeadersList() {
+                public List<UnleashRuntimeTimeConfig.CustomHeader> customHeaders() {
                     return List.of();
                 }
             };

--- a/test/src/main/java/io/quarkiverse/unleash/UnleashTestResource.java
+++ b/test/src/main/java/io/quarkiverse/unleash/UnleashTestResource.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.unleash;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -136,6 +137,11 @@ public class UnleashTestResource implements QuarkusTestResourceLifecycleManager,
                 @Override
                 public Map<String, String> customHeaders() {
                     return Map.of();
+                }
+
+                @Override
+                public List<UnleashRuntimeTimeConfig.CustomHeader> customHeadersList() {
+                    return List.of();
                 }
             };
 


### PR DESCRIPTION
Adds support for specifying custom header which is present in [unleash-sdk](https://github.com/Unleash/unleash-java-sdk?tab=readme-ov-file#custom-http-headers).

This feature is useful for custom auth, correlation IDs, API gateway requirements, etc. 
There are two possible configuration formats to enable flexibility.
